### PR TITLE
Set a default value when setting back scrolling on select blur as o, …

### DIFF
--- a/src/wwElement_Select.vue
+++ b/src/wwElement_Select.vue
@@ -161,6 +161,7 @@ export default {
         const mappingValue = computed(() => props.content.mappingValue);
         const mappingDisabled = computed(() => props.content.mappingDisabled);
         const showSearch = computed(() => props.content.showSearch);
+        const allowScrollingWhenOpen = computed(() => props.content.allowScrollingWhenOpen);
 
         // Styles
         const syncFloating = () => {
@@ -524,9 +525,9 @@ export default {
             nextTick(syncFloating);
             handleInitialFocus();
             if (isOpen.value) {
-                blockScrolling();
+                if (!allowScrollingWhenOpen.value) blockScrolling();
             } else {
-                revertBlockScrolling();
+                if (!allowScrollingWhenOpen.value) revertBlockScrolling();
             }
         });
 

--- a/src/wwElement_Select.vue
+++ b/src/wwElement_Select.vue
@@ -478,18 +478,19 @@ export default {
         };
         const revertBlockScrolling = () => {
             const _d = wwLib.getFrontDocument();
+
             if (!_d) return;
 
             if (initialOverflow === null) return;
             if (initialBodyOverflow === null) return;
 
-            _d.documentElement.style.overflow = initialOverflow.overflow;
-            _d.documentElement.style.overflowX = initialOverflow.overflowX;
-            _d.documentElement.style.overflowY = initialOverflow.overflowY;
-            _d.body.style.overflow = initialBodyOverflow.overflow;
-            _d.body.style.overflowX = initialBodyOverflow.overflowX;
-            _d.body.style.overflowY = initialBodyOverflow.overflowY;
-            _d.documentElement.style.paddingRight = initialPaddingRight;
+            _d.documentElement.style.overflow = initialOverflow.overflow || '';
+            _d.documentElement.style.overflowX = initialOverflow.overflowX || '';
+            _d.documentElement.style.overflowY = initialOverflow.overflowY || '';
+            _d.body.style.overflow = initialBodyOverflow.overflow || '';
+            _d.body.style.overflowX = initialBodyOverflow.overflowX || '';
+            _d.body.style.overflowY = initialBodyOverflow.overflowY || '';
+            _d.documentElement.style.paddingRight = initialPaddingRight || '';
 
             initialOverflow = null;
             initialBodyOverflow = null;

--- a/src/wwElement_Select.vue
+++ b/src/wwElement_Select.vue
@@ -461,40 +461,72 @@ export default {
         });
 
         let initialOverflow = null;
-        let initialBodyOverflow = null;
+        let initialBodyStyle = null;
+        let initialTouchAction = null;
         let initialPaddingRight = '0px';
+        let supportsPassive = false;
+        let wheelOpt = false;
+        let wheelEvent = '';
+
+        // Initialize passive event support detection
+        try {
+            window.addEventListener("test", null, Object.defineProperty({}, 'passive', {
+                get: function () { supportsPassive = true; } 
+            }));
+        } catch(e) {}
+
+        wheelOpt = supportsPassive ? { passive: false } : false;
+        wheelEvent = 'onwheel' in document.createElement('div') ? 'wheel' : 'mousewheel';
+
+        const preventDefault = (e) => {
+            e.preventDefault();
+        };
+
+        const preventDefaultForScrollKeys = (e) => {
+            const keys = { 37: 1, 38: 1, 39: 1, 40: 1 };
+            if (keys[e.keyCode]) {
+                preventDefault(e);
+                return false;
+            }
+        };
+
         const blockScrolling = () => {
             const _w = wwLib.getFrontWindow();
             const _d = wwLib.getFrontDocument();
+
             if (!_w || !_d) return;
 
-            const scrollbarWidth = _w.innerWidth - _d.documentElement.clientWidth;
             initialOverflow = { ..._d.documentElement.style };
-            initialBodyOverflow = { ..._d.body.style };
-            initialPaddingRight = _d.documentElement.style.paddingRight;
+            initialBodyStyle = { ..._d.body.style };
+            _d.body.style.touchAction = 'none';
 
-            _d.documentElement.style.overflow = 'hidden';
-            _d.body.style.overflow = 'hidden';
-            _d.documentElement.style.paddingRight = `${scrollbarWidth}px`;
+            // Add event listeners to prevent scrolling
+            _w.addEventListener('DOMMouseScroll', preventDefault, false);
+            _w.addEventListener(wheelEvent, preventDefault, wheelOpt);
+            _w.addEventListener('touchmove', preventDefault, wheelOpt);
+            _w.addEventListener('keydown', preventDefaultForScrollKeys, false);
         };
+
         const revertBlockScrolling = () => {
             const _d = wwLib.getFrontDocument();
+            const _w = wwLib.getFrontWindow();
 
-            if (!_d) return;
+            if (!_d || !_w) return;
 
             if (initialOverflow === null) return;
-            if (initialBodyOverflow === null) return;
+            if (initialBodyStyle === null) return;
 
-            _d.documentElement.style.overflow = initialOverflow.overflow || '';
-            _d.documentElement.style.overflowX = initialOverflow.overflowX || '';
-            _d.documentElement.style.overflowY = initialOverflow.overflowY || '';
-            _d.body.style.overflow = initialBodyOverflow.overflow || '';
-            _d.body.style.overflowX = initialBodyOverflow.overflowX || '';
-            _d.body.style.overflowY = initialBodyOverflow.overflowY || '';
-            _d.documentElement.style.paddingRight = initialPaddingRight || '';
+            _d.body.style.touchAction = initialTouchAction || '';
+            _d.body.style['touch-action'] = initialTouchAction || '';
+
+            // Remove event listeners
+            _w.removeEventListener('DOMMouseScroll', preventDefault, false);
+            _w.removeEventListener(wheelEvent, preventDefault, wheelOpt);
+            _w.removeEventListener('touchmove', preventDefault, wheelOpt);
+            _w.removeEventListener('keydown', preventDefaultForScrollKeys, false);
 
             initialOverflow = null;
-            initialBodyOverflow = null;
+            initialBodyStyle = null;
         };
 
         watch(

--- a/ww-config.js
+++ b/ww-config.js
@@ -146,6 +146,7 @@ export default {
             'mappingDisabled',
             'initValueSingle',
             'initValueMulti',
+            'allowScrollingWhenOpen',
             [
                 'triggerTitle',
                 'placeholder',
@@ -797,6 +798,24 @@ export default {
             type: 'OnOff',
             defaultValue: false,
             editorOnly: true,
+            section: 'settings',
+        },
+        allowScrollingWhenOpen: {
+            label: { en: 'Allow scrolling when open' },
+            type: 'OnOff',
+            defaultValue: false,
+            states: true,
+            bindable: true,
+            responsive: true,
+            propertyHelp: {
+                tooltip:
+                    'This should be disabled in some edge cases like in popups, datagrid, etc.',
+            },
+            bindingValidation: {
+                type: 'boolean',
+                tooltip:
+                    'This should be disabled in some edge cases like in popups, datagrid, etc. A boolean value: \n\n`true` or `false`',
+            },
             section: 'settings',
         },
         optionProperties: {


### PR DESCRIPTION
…safari those are undefined and not empty string

The error was for IOS but also MAC, in fact => SAFARI 

Before : we saved initial styles => then setting them back

The issue is safari do not provide the same "initial styles" object as chrome, but only style that are not ""
=> So setting them back mean setting "undefined" so if initial overflow "" is not setting back to "" but undefifined

The fix : just setting empty string if navigator do not include the unchanged styles 