### PR TITLE
[WW-3770] Add focus state for select input

### DIFF
--- a/src/wwElement_Option.vue
+++ b/src/wwElement_Option.vue
@@ -4,6 +4,9 @@
         :style="optionStyles"
         ref="optionRef"
         @click="handleClick"
+        @mousedown="handleMouseDown"
+        @mouseup="handleMouseUp"
+        @mouseleave="handleMouseLeave"
         @keydown="handleKeyDown"
         role="option"
         :id="optionId"
@@ -16,7 +19,7 @@
 </template>
 
 <script>
-import { ref, unref, toValue, inject, computed, watch, onBeforeUnmount, watchEffect } from 'vue';
+import { ref, unref, toValue, inject, computed, watch, onBeforeUnmount, watchEffect, nextTick } from 'vue';
 import useAccessibility from './useAccessibility_Option';
 /* wwEditor:start */
 import useEditorHint from './editor/useEditorHint';
@@ -64,6 +67,7 @@ export default {
         const updateValue = inject('_wwSelect:updateValue', () => {});
         const focusSelectElement = inject('_wwSelect:focusSelectElement', () => {});
         const activeDescendant = inject('_wwSelect:activeDescendant', ref(null));
+        const isMouseDownOnOption = inject('_wwSelect:isMouseDownOnOption', ref(false));
 
         const mappingLabel = inject('_wwSelect:mappingLabel', ref(null));
         const mappingValue = inject('_wwSelect:mappingValue', ref(null));
@@ -152,6 +156,23 @@ export default {
             }
         };
 
+        const handleMouseDown = (event) => {
+            // Track mousedown to prevent blur on the select element
+            isMouseDownOnOption.value = true;
+        };
+
+        const handleMouseUp = () => {
+            // Reset the flag after mouseup
+            nextTick(() => {
+                isMouseDownOnOption.value = false;
+            });
+        };
+
+        const handleMouseLeave = () => {
+            // Also reset if mouse leaves the option while pressed
+            isMouseDownOnOption.value = false;
+        };
+
         // Maybe => move this to the select component (selectType too + new isSelected function in the select)
         const unselect = () => {
             if (canInteract.value) {
@@ -230,6 +251,9 @@ export default {
             optionRef,
             optionId,
             handleClick,
+            handleMouseDown,
+            handleMouseUp,
+            handleMouseLeave,
             handleKeyDown,
             isFocused,
             activeDescendant,

--- a/src/wwElement_Search.vue
+++ b/src/wwElement_Search.vue
@@ -89,15 +89,11 @@ export default {
         };
 
         const handleSearchFocus = () => {
-            if (isSearchBarFocused) {
-                isSearchBarFocused.value = true;
-            }
+            isSearchBarFocused.value = true;
         };
 
         const handleSearchBlur = () => {
-            if (isSearchBarFocused) {
-                isSearchBarFocused.value = false;
-            }
+            isSearchBarFocused.value = false;
         };
 
         watch(searchElement, value => {

--- a/src/wwElement_Search.vue
+++ b/src/wwElement_Search.vue
@@ -5,6 +5,8 @@
         :style="[searchStyles]"
         :class="['ww-select-search']"
         @input="handleInputChange"
+        @focus="handleSearchFocus"
+        @blur="handleSearchBlur"
         :placeholder="searchPlaceholder"
     />
 </template>
@@ -29,7 +31,7 @@ export default {
         /* wwEditor:start */
         useEditorHint(emit);
         /* wwEditor:end */
-        const { updateHasSearch, updateSearchElement, updateSearch, autoFocusSearch, focusSearch } = inject(
+        const { updateHasSearch, updateSearchElement, updateSearch, autoFocusSearch, focusSearch, isSearchBarFocused } = inject(
             '_wwSelect:useSearch',
             {}
         );
@@ -86,6 +88,18 @@ export default {
             debouncedUpdateSearch(event?.target?.value, searchBy);
         };
 
+        const handleSearchFocus = () => {
+            if (isSearchBarFocused) {
+                isSearchBarFocused.value = true;
+            }
+        };
+
+        const handleSearchBlur = () => {
+            if (isSearchBarFocused) {
+                isSearchBarFocused.value = false;
+            }
+        };
+
         watch(searchElement, value => {
             if (updateSearchElement) updateSearchElement(value);
         });
@@ -102,6 +116,8 @@ export default {
         return {
             searchElementRef,
             handleInputChange,
+            handleSearchFocus,
+            handleSearchBlur,
             searchStyles,
             searchPlaceholder,
         };

--- a/src/wwElement_Select.vue
+++ b/src/wwElement_Select.vue
@@ -148,6 +148,7 @@ export default {
         const options = computed(() => Array.from(optionsMap.value.values()));
         const isOpen = ref(false);
         const isReallyFocused = ref(false);
+        const isSearchBarFocused = ref(false);
         const rawData = computed(() => props.content.choices || []);
 
         const isFocused = computed(() => {
@@ -157,6 +158,15 @@ export default {
             }
             /* wwEditor:end */
             return isReallyFocused.value;
+        });
+
+        const isAnySelectElementFocused = computed(() => {
+            /* wwEditor:start */
+            if (props.wwEditorState?.isSelected) {
+                return props.wwElementState.states.includes('focus');
+            }
+            /* wwEditor:end */
+            return isReallyFocused.value || isSearchBarFocused.value;
         });
         const isDisabled = computed(() => props.content.disabled || false);
         const isReadonly = computed(() => props.content.readonly || false);
@@ -618,7 +628,7 @@ export default {
             }
         });
 
-        watch(isFocused, (value) => {
+        watch(isAnySelectElementFocused, (value) => {
             if (value) {
                 emit('add-state', 'focus');
             } else {
@@ -775,7 +785,7 @@ export default {
         provide('_wwSelect:registerOptionProperties', registerOptionProperties);
         provide('_wwSelect:registerTriggerLocalContext', registerTriggerLocalContext);
         provide('_wwSelect:dropdownMethods', { closeDropdown });
-        provide('_wwSelect:useSearch', { updateHasSearch, updateSearchElement, updateSearch, updateAutoFocusSearch });
+        provide('_wwSelect:useSearch', { updateHasSearch, updateSearchElement, updateSearch, updateAutoFocusSearch, isSearchBarFocused });
         provide('_wwSelect:localContext', currentLocalContext);
 
         const markdown = `### Select local informations
@@ -847,7 +857,9 @@ export default {
             forceOpenInEditor,
             isOpen,
             isReallyFocused,
+            isSearchBarFocused,
             isFocused,
+            isAnySelectElementFocused,
             triggerElement,
             dropdownElement,
             floatingStyles,

--- a/src/wwElement_Select.vue
+++ b/src/wwElement_Select.vue
@@ -938,6 +938,11 @@ export default {
 
 .ww-select {
     position: relative;
+    outline: none;
+}
+
+.ww-select:focus-visible {
+    outline: none;
 }
 
 .ww-select-z-index {
@@ -946,6 +951,11 @@ export default {
 
 .ww-select__trigger {
     width: 100%;
+    outline: none;
+}
+
+.ww-select__trigger:focus-visible {
+    outline: none;
 }
 
 .ww-select__dropdown__wrapper {
@@ -984,5 +994,11 @@ export default {
     position: absolute;
     right: 0;
     width: 100%;
+}
+</style>
+
+<style lang="scss">
+.ww-element:focus-visible {
+    outline: none;
 }
 </style>

--- a/src/wwElement_Select.vue
+++ b/src/wwElement_Select.vue
@@ -149,6 +149,7 @@ export default {
         const isOpen = ref(false);
         const isReallyFocused = ref(false);
         const isSearchBarFocused = ref(false);
+        const isMouseDownOnOption = ref(false);
         const rawData = computed(() => props.content.choices || []);
 
         const isFocused = computed(() => {
@@ -370,6 +371,7 @@ export default {
             updateSearch,
         });
 
+
         function openDropdown() {
             if (isDisabled.value || isReadonly.value) return;
             const triggerElementBounding = triggerElement.value.getBoundingClientRect();
@@ -424,7 +426,10 @@ export default {
         }
 
         function handleBlur() {
-            isReallyFocused.value = false;
+            // Don't blur if we're clicking on an option
+            if (!isMouseDownOnOption.value) {
+                isReallyFocused.value = false;
+            }
         }
 
         function focusInput() {
@@ -786,6 +791,7 @@ export default {
         provide('_wwSelect:registerTriggerLocalContext', registerTriggerLocalContext);
         provide('_wwSelect:dropdownMethods', { closeDropdown });
         provide('_wwSelect:useSearch', { updateHasSearch, updateSearchElement, updateSearch, updateAutoFocusSearch, isSearchBarFocused });
+        provide('_wwSelect:isMouseDownOnOption', isMouseDownOnOption);
         provide('_wwSelect:localContext', currentLocalContext);
 
         const markdown = `### Select local informations
@@ -994,11 +1000,5 @@ export default {
     position: absolute;
     right: 0;
     width: 100%;
-}
-</style>
-
-<style lang="scss">
-.ww-element:focus-visible {
-    outline: none;
 }
 </style>

--- a/ww-config.js
+++ b/ww-config.js
@@ -180,10 +180,12 @@ export default {
         displayAllowedValues: ['block'],
         //ignoredStyleProperties: ['border','borderRadius','background','outline'],
     },
-    states: ['readonly'],
+    states: ['focus', 'readonly'],
     triggerEvents: [
         { name: 'change', label: { en: 'On change' }, event: { value: '' }, default: true },
         { name: 'initValueChange', label: { en: 'On init value change' }, event: { value: '' } },
+        { name: 'focus', label: { en: 'On focus' }, event: null },
+        { name: 'blur', label: { en: 'On blur' }, event: null },
     ],
     actions: [
         {
@@ -231,6 +233,11 @@ export default {
         {
             label: 'Reset search',
             action: 'actionResetSearch',
+            args: [],
+        },
+        {
+            label: 'Focus',
+            action: 'actionFocusInput',
             args: [],
         },
     ],

--- a/ww-config.js
+++ b/ww-config.js
@@ -184,8 +184,8 @@ export default {
     triggerEvents: [
         { name: 'change', label: { en: 'On change' }, event: { value: '' }, default: true },
         { name: 'initValueChange', label: { en: 'On init value change' }, event: { value: '' } },
-        { name: 'focus', label: { en: 'On focus' }, event: null },
-        { name: 'blur', label: { en: 'On blur' }, event: null },
+        { name: 'focus', label: { en: 'On focus' }, event: { value: '' } },
+        { name: 'blur', label: { en: 'On blur' }, event: { value: '' } },
     ],
     actions: [
         {


### PR DESCRIPTION
## Summary
- Add focus state support for ww-input-select component
- Implement combined focus tracking for both trigger and search input elements
- Add focus/blur trigger events and programmatic focus action

## Changes
- **Configuration**: Added 'focus' to states array, focus/blur trigger events, and Focus action
- **Focus State Management**: Track focus on both trigger element and search input
- **Event Handling**: Emit focus/blur events for workflows, add-state/remove-state for styling
- **Search Integration**: Search input focus contributes to overall select focus state

## Benefits  
- Users can configure focus-specific styling in WeWeb editor
- Focus state persists when moving between trigger and search input
- Focus/blur events available for workflows
- Programmatic focus capability via Focus action
- Consistent with other WeWeb input components

## Test Plan
- [ ] Verify focus styling applies when focusing trigger element
- [ ] Verify focus styling applies when focusing search input  
- [ ] Verify focus state persists when moving between trigger and search
- [ ] Verify focus/blur events fire correctly
- [ ] Test programmatic focus action
- [ ] Test in WeWeb editor with state preview