### PR TITLE
[WW-3704] Fix change event not triggered when unselecting option

### DIFF
--- a/src/select/useAccessibility.js
+++ b/src/select/useAccessibility.js
@@ -83,7 +83,7 @@ export default function useAccessibility({
             },
             Enter: () => {
                 event.preventDefault();
-                if (isOpen.value && activeOptionValue.value != null && activeOptionValue.value !== undefined) {
+                if (isOpen.value && activeOptionValue.value != null && activeOptionValue.value !== undefined && activeOptionValue.value !== '') {
                     toggleValue(activeOptionValue.value);
                 } else if (!isOpen.value) {
                     openDropdown();

--- a/src/wwElement_Option.vue
+++ b/src/wwElement_Option.vue
@@ -156,16 +156,11 @@ export default {
         // Maybe => move this to the select component (selectType too + new isSelected function in the select)
         const unselect = () => {
             if (canInteract.value) {
-                console.log('[Option Unselect] Starting unselect for type:', selectType.value, 'value:', value.value);
                 if (selectType.value === 'single') {
-                    console.log('[Option Unselect] Single select: calling updateValue(null)');
                     updateValue(null);
                 } else {
-                    console.log('[Option Unselect] Multiple select: calling removeSpecificValue');
                     removeSpecificValue(value.value);
                 }
-            } else {
-                console.log('[Option Unselect] Cannot interact - canInteract is false');
             }
         };
 

--- a/src/wwElement_Option.vue
+++ b/src/wwElement_Option.vue
@@ -184,7 +184,9 @@ export default {
                         valueToRemove: value.value,
                         newValue
                     });
-                    updateValue(newValue);
+                    console.log('Bypassing updateValue, calling setValue and emit directly');
+                    setValue(newValue);
+                    emit('trigger-event', { name: 'change', event: { value: newValue } });
                 }
             } else {
                 console.log('Cannot interact, unselect aborted');

--- a/src/wwElement_Option.vue
+++ b/src/wwElement_Option.vue
@@ -156,13 +156,11 @@ export default {
         const unselect = () => {
             if (canInteract.value) {
                 if (selectType.value === 'single') {
-                    setValue(null);
-                    emit('trigger-event', { name: 'change', event: { value: null } });
+                    updateValue(null);
                 } else {
                     const currentValue = Array.isArray(selectValue.value) ? [...selectValue.value] : [];
                     const newValue = currentValue.filter(v => v !== value.value);
-                    setValue(newValue);
-                    emit('trigger-event', { name: 'change', event: { value: newValue } });
+                    updateValue(newValue);
                 }
             }
         };

--- a/src/wwElement_Option.vue
+++ b/src/wwElement_Option.vue
@@ -142,10 +142,21 @@ export default {
         );
 
         const handleClick = () => {
+            console.log('Option click:', {
+                isSelected: isSelected.value,
+                canInteract: canInteract.value,
+                unselectOnClick: props.content.unselectOnClick,
+                selectOnClick: props.content.selectOnClick,
+                selectType: selectType.value,
+                currentValue: value.value
+            });
+            
             if (isSelected.value && canInteract.value && props.content.unselectOnClick) {
+                console.log('Calling unselect for option:', value.value);
                 unselect();
                 focusFromOptionId(null);
             } else if (!isSelected.value && canInteract.value && props.content.selectOnClick) {
+                console.log('Calling updateValue for option:', value.value);
                 updateValue(value.value);
                 focusFromOptionId(optionId);
                 focusSelectElement();
@@ -154,14 +165,29 @@ export default {
 
         // Maybe => move this to the select component (selectType too + new isSelected function in the select)
         const unselect = () => {
+            console.log('Unselect called with:', {
+                canInteract: canInteract.value,
+                selectType: selectType.value,
+                currentSelectValue: selectValue.value,
+                optionValue: value.value
+            });
+            
             if (canInteract.value) {
                 if (selectType.value === 'single') {
+                    console.log('Single select: calling updateValue(null)');
                     updateValue(null);
                 } else {
                     const currentValue = Array.isArray(selectValue.value) ? [...selectValue.value] : [];
                     const newValue = currentValue.filter(v => v !== value.value);
+                    console.log('Multiple select:', {
+                        currentValue,
+                        valueToRemove: value.value,
+                        newValue
+                    });
                     updateValue(newValue);
                 }
+            } else {
+                console.log('Cannot interact, unselect aborted');
             }
         };
 

--- a/src/wwElement_Option.vue
+++ b/src/wwElement_Option.vue
@@ -157,9 +157,12 @@ export default {
             if (canInteract.value) {
                 if (selectType.value === 'single') {
                     setValue(null);
+                    emit('trigger-event', { name: 'change', event: { value: null } });
                 } else {
                     const currentValue = Array.isArray(selectValue.value) ? [...selectValue.value] : [];
-                    setValue(currentValue.filter(v => v !== value.value));
+                    const newValue = currentValue.filter(v => v !== value.value);
+                    setValue(newValue);
+                    emit('trigger-event', { name: 'change', event: { value: newValue } });
                 }
             }
         };

--- a/src/wwElement_Option.vue
+++ b/src/wwElement_Option.vue
@@ -155,14 +155,20 @@ export default {
         // Maybe => move this to the select component (selectType too + new isSelected function in the select)
         const unselect = () => {
             if (canInteract.value) {
+                console.log('[Option Unselect] Starting unselect for type:', selectType.value, 'value:', value.value);
                 if (selectType.value === 'single') {
+                    console.log('[Option Unselect] Single select: calling updateValue(null)');
                     updateValue(null);
                 } else {
+                    console.log('[Option Unselect] Multiple select: manually handling unselect');
                     const currentValue = Array.isArray(selectValue.value) ? [...selectValue.value] : [];
                     const newValue = currentValue.filter(v => v !== value.value);
+                    console.log('[Option Unselect] Multiple select: emitting change event with newValue:', newValue);
                     setValue(newValue);
                     emit('trigger-event', { name: 'change', event: { value: newValue } });
                 }
+            } else {
+                console.log('[Option Unselect] Cannot interact - canInteract is false');
             }
         };
 

--- a/src/wwElement_Option.vue
+++ b/src/wwElement_Option.vue
@@ -62,6 +62,7 @@ export default {
         const isDisabled = inject('_wwSelect:isDisabled', ref(false));
         const isReadonly = inject('_wwSelect:isReadonly', ref(false));
         const updateValue = inject('_wwSelect:updateValue', () => {});
+        const removeSpecificValue = inject('_wwSelect:removeSpecificValue', () => {});
         const focusSelectElement = inject('_wwSelect:focusSelectElement', () => {});
         const activeDescendant = inject('_wwSelect:activeDescendant', ref(null));
 
@@ -160,12 +161,8 @@ export default {
                     console.log('[Option Unselect] Single select: calling updateValue(null)');
                     updateValue(null);
                 } else {
-                    console.log('[Option Unselect] Multiple select: manually handling unselect');
-                    const currentValue = Array.isArray(selectValue.value) ? [...selectValue.value] : [];
-                    const newValue = currentValue.filter(v => v !== value.value);
-                    console.log('[Option Unselect] Multiple select: emitting change event with newValue:', newValue);
-                    setValue(newValue);
-                    emit('trigger-event', { name: 'change', event: { value: newValue } });
+                    console.log('[Option Unselect] Multiple select: calling removeSpecificValue');
+                    removeSpecificValue(value.value);
                 }
             } else {
                 console.log('[Option Unselect] Cannot interact - canInteract is false');

--- a/src/wwElement_Option.vue
+++ b/src/wwElement_Option.vue
@@ -142,21 +142,10 @@ export default {
         );
 
         const handleClick = () => {
-            console.log('Option click:', {
-                isSelected: isSelected.value,
-                canInteract: canInteract.value,
-                unselectOnClick: props.content.unselectOnClick,
-                selectOnClick: props.content.selectOnClick,
-                selectType: selectType.value,
-                currentValue: value.value
-            });
-            
             if (isSelected.value && canInteract.value && props.content.unselectOnClick) {
-                console.log('Calling unselect for option:', value.value);
                 unselect();
                 focusFromOptionId(null);
             } else if (!isSelected.value && canInteract.value && props.content.selectOnClick) {
-                console.log('Calling updateValue for option:', value.value);
                 updateValue(value.value);
                 focusFromOptionId(optionId);
                 focusSelectElement();
@@ -165,31 +154,15 @@ export default {
 
         // Maybe => move this to the select component (selectType too + new isSelected function in the select)
         const unselect = () => {
-            console.log('Unselect called with:', {
-                canInteract: canInteract.value,
-                selectType: selectType.value,
-                currentSelectValue: selectValue.value,
-                optionValue: value.value
-            });
-            
             if (canInteract.value) {
                 if (selectType.value === 'single') {
-                    console.log('Single select: calling updateValue(null)');
                     updateValue(null);
                 } else {
                     const currentValue = Array.isArray(selectValue.value) ? [...selectValue.value] : [];
                     const newValue = currentValue.filter(v => v !== value.value);
-                    console.log('Multiple select:', {
-                        currentValue,
-                        valueToRemove: value.value,
-                        newValue
-                    });
-                    console.log('Bypassing updateValue, calling setValue and emit directly');
                     setValue(newValue);
                     emit('trigger-event', { name: 'change', event: { value: newValue } });
                 }
-            } else {
-                console.log('Cannot interact, unselect aborted');
             }
         };
 

--- a/src/wwElement_Select.vue
+++ b/src/wwElement_Select.vue
@@ -230,14 +230,12 @@ export default {
         };
 
         const updateValue = value => {
-            console.log('[Select updateValue] Called with value:', value, 'type:', selectType.value);
             if (selectType.value === 'single') {
                 // Check if value is an array
                 if (Array.isArray(value)) {
                     console.warn('Single select component received an array value. Only the first value will be used.');
                     value = value[0];
                 }
-                console.log('[Select updateValue] Single select: setting value and emitting change event:', value);
                 setValue(value);
                 emit('trigger-event', { name: 'change', event: { value } });
             } else {
@@ -260,7 +258,6 @@ export default {
                     }
                 }
 
-                console.log('[Select updateValue] Multiple select: setting value and emitting change event:', currentValue);
                 setValue(currentValue);
                 emit('trigger-event', { name: 'change', event: { value: currentValue } });
             }
@@ -269,11 +266,8 @@ export default {
         };
 
         const toggleValueAccessibility = value => {
-            console.log('[Select toggleValueAccessibility] Called with value:', value, 'type:', selectType.value);
-            
             // Don't process empty values
             if (value === '' || value == null || value === undefined) {
-                console.log('[Select toggleValueAccessibility] Ignoring empty/null/undefined value');
                 return;
             }
             
@@ -289,11 +283,9 @@ export default {
                 if (variableValue.value === value) {
                     // Unselect ?
                     if (props.content.unselectOnClick) {
-                        console.log('[Select toggleValueAccessibility] Single unselect via keyboard');
                         setValue(null);
                         valueChanged = true;
                         if (props.content.closeOnSelect) {
-                            console.log('[Select toggleValueAccessibility] Closing dropdown due to closeOnSelect');
                             closeDropdown();
                         }
                     }
@@ -321,11 +313,9 @@ export default {
                 if (valueIndex >= 0) {
                     // Unelect ?
                     if (props.content.unselectOnClick) {
-                        console.log('[Select toggleValueAccessibility] Multiple unselect via keyboard');
                         currentValue.splice(valueIndex, 1);
                         valueChanged = true;
                         if (props.content.closeOnSelect) {
-                            console.log('[Select toggleValueAccessibility] Closing dropdown due to closeOnSelect');
                             closeDropdown();
                         }
                     }
@@ -347,9 +337,7 @@ export default {
         };
 
         function removeSpecificValue(valueToRemove) {
-            console.log('[Select removeSpecificValue] Called with value:', valueToRemove);
             if (selectType.value !== 'multiple' || isDisabled.value || isReadonly.value) {
-                console.log('[Select removeSpecificValue] Blocked - type:', selectType.value, 'disabled:', isDisabled.value, 'readonly:', isReadonly.value);
                 return;
             }
 
@@ -372,12 +360,10 @@ export default {
                 setValue(currentValue);
             }
 
-            console.log('[Select removeSpecificValue] Emitting change event with value:', currentValue);
             emit('trigger-event', { name: 'change', event: { value: currentValue } });
             
             // Close dropdown if closeOnSelect is enabled, just like regular selection
             if (props.content.closeOnSelect) {
-                console.log('[Select removeSpecificValue] Closing dropdown due to closeOnSelect setting');
                 // Re-enable closing first, then close
                 shouldCloseDropdown.value = true;
                 closeDropdown();

--- a/src/wwElement_Select.vue
+++ b/src/wwElement_Select.vue
@@ -270,6 +270,13 @@ export default {
 
         const toggleValueAccessibility = value => {
             console.log('[Select toggleValueAccessibility] Called with value:', value, 'type:', selectType.value);
+            
+            // Don't process empty values
+            if (value === '' || value == null || value === undefined) {
+                console.log('[Select toggleValueAccessibility] Ignoring empty/null/undefined value');
+                return;
+            }
+            
             const option = Array.from(optionsMap.value).find(([key, option]) => option.value === value);
             if (!option && !options?.length > 1) return;
             if (option?.[1]?.disabled) return;

--- a/src/wwElement_Select.vue
+++ b/src/wwElement_Select.vue
@@ -360,12 +360,14 @@ export default {
             // Close dropdown if closeOnSelect is enabled, just like regular selection
             if (props.content.closeOnSelect) {
                 console.log('[Select removeSpecificValue] Closing dropdown due to closeOnSelect setting');
-                closeDropdown();
-            }
-            
-            setTimeout(() => {
+                // Re-enable closing first, then close
                 shouldCloseDropdown.value = true;
-            }, 200);
+                closeDropdown();
+            } else {
+                nextTick(() => {
+                    shouldCloseDropdown.value = true;
+                });
+            }
         }
 
         const {

--- a/src/wwElement_Select.vue
+++ b/src/wwElement_Select.vue
@@ -270,14 +270,21 @@ export default {
             if (!option && !options?.length > 1) return;
             if (option?.[1]?.disabled) return;
 
+            const originalValue = selectType.value === 'single' ? variableValue.value : [...(Array.isArray(variableValue.value) ? variableValue.value : [])];
+            let valueChanged = false;
             let eventValue;
+
             if (selectType.value === 'single') {
                 if (variableValue.value === value) {
                     // Unselect ?
-                    if (props.content.unselectOnClick) setValue(null);
+                    if (props.content.unselectOnClick) {
+                        setValue(null);
+                        valueChanged = true;
+                    }
                 } else if (props.content.selectOnClick) {
                     // Select ?
                     setValue(value);
+                    valueChanged = true;
                     if (props.content.closeOnSelect) closeDropdown();
                 }
                 eventValue = variableValue.value;
@@ -297,10 +304,14 @@ export default {
 
                 if (valueIndex >= 0) {
                     // Unelect ?
-                    if (props.content.unselectOnClick) currentValue.splice(valueIndex, 1);
+                    if (props.content.unselectOnClick) {
+                        currentValue.splice(valueIndex, 1);
+                        valueChanged = true;
+                    }
                 } else if (props.content.selectOnClick) {
                     // Select ?
                     currentValue.push(value);
+                    valueChanged = true;
                     if (props.content.closeOnSelect) closeDropdown();
                 }
 
@@ -308,7 +319,10 @@ export default {
                 eventValue = currentValue;
             }
 
-            emit('trigger-event', { name: 'change', event: { value: eventValue } });
+            // Only emit change event if the value actually changed
+            if (valueChanged) {
+                emit('trigger-event', { name: 'change', event: { value: eventValue } });
+            }
         };
 
         function removeSpecificValue(valueToRemove) {

--- a/src/wwElement_Select.vue
+++ b/src/wwElement_Select.vue
@@ -230,12 +230,19 @@ export default {
         };
 
         const updateValue = value => {
+            console.log('updateValue called with:', {
+                value,
+                selectType: selectType.value,
+                currentVariableValue: variableValue.value
+            });
+            
             if (selectType.value === 'single') {
                 // Check if value is an array
                 if (Array.isArray(value)) {
                     console.warn('Single select component received an array value. Only the first value will be used.');
                     value = value[0];
                 }
+                console.log('Single select: setting value to:', value);
                 setValue(value);
                 emit('trigger-event', { name: 'change', event: { value } });
             } else {
@@ -245,19 +252,31 @@ export default {
                 }
 
                 const currentValue = Array.isArray(variableValue.value) ? [...variableValue.value] : [];
+                console.log('Multiple select processing:', {
+                    incomingValue: value,
+                    currentValue: currentValue
+                });
+                
                 for (let iValue of value) {
                     // Find index using the utility function
                     const valueIndex = findValueIndex(currentValue, iValue);
+                    console.log('Processing value:', iValue, 'found at index:', valueIndex);
 
                     if (valueIndex === -1) {
-                        if (!props.content.limit || currentValue.length < props.content.limit)
+                        if (!props.content.limit || currentValue.length < props.content.limit) {
+                            console.log('Adding value:', iValue);
                             currentValue.push(iValue);
+                        } else {
+                            console.log('Limit reached, not adding:', iValue);
+                        }
                     } else {
+                        console.log('Value already exists at index', valueIndex, '- NOT REMOVING (commented out)');
                         // currentValue.splice(valueIndex, 1);
                         // No need to unselect
                     }
                 }
 
+                console.log('Final value for multiple select:', currentValue);
                 setValue(currentValue);
                 emit('trigger-event', { name: 'change', event: { value: currentValue } });
             }

--- a/src/wwElement_Select.vue
+++ b/src/wwElement_Select.vue
@@ -329,7 +329,11 @@ export default {
         };
 
         function removeSpecificValue(valueToRemove) {
-            if (selectType.value !== 'multiple' || isDisabled.value || isReadonly.value) return;
+            console.log('[Select removeSpecificValue] Called with value:', valueToRemove);
+            if (selectType.value !== 'multiple' || isDisabled.value || isReadonly.value) {
+                console.log('[Select removeSpecificValue] Blocked - type:', selectType.value, 'disabled:', isDisabled.value, 'readonly:', isReadonly.value);
+                return;
+            }
 
             /* This is a workaround to prevent the dropdown from closing when removing a value.
              * The issue is that the click event that triggers this function also bubbles up
@@ -350,6 +354,7 @@ export default {
                 setValue(currentValue);
             }
 
+            console.log('[Select removeSpecificValue] Emitting change event with value:', currentValue);
             emit('trigger-event', { name: 'change', event: { value: currentValue } });
             setTimeout(() => {
                 shouldCloseDropdown.value = true;
@@ -747,6 +752,7 @@ export default {
         provide('_wwSelect:searchState', searchState);
         provide('_wwSelect:optionProperties', optionProperties);
         provide('_wwSelect:updateValue', updateValue);
+        provide('_wwSelect:removeSpecificValue', removeSpecificValue);
         provide('_wwSelect:registerOption', registerOption);
         provide('_wwSelect:unregisterOption', unregisterOption);
         provide('_wwSelect:registerOptionProperties', registerOptionProperties);

--- a/src/wwElement_Select.vue
+++ b/src/wwElement_Select.vue
@@ -230,12 +230,14 @@ export default {
         };
 
         const updateValue = value => {
+            console.log('[Select updateValue] Called with value:', value, 'type:', selectType.value);
             if (selectType.value === 'single') {
                 // Check if value is an array
                 if (Array.isArray(value)) {
                     console.warn('Single select component received an array value. Only the first value will be used.');
                     value = value[0];
                 }
+                console.log('[Select updateValue] Single select: setting value and emitting change event:', value);
                 setValue(value);
                 emit('trigger-event', { name: 'change', event: { value } });
             } else {
@@ -258,6 +260,7 @@ export default {
                     }
                 }
 
+                console.log('[Select updateValue] Multiple select: setting value and emitting change event:', currentValue);
                 setValue(currentValue);
                 emit('trigger-event', { name: 'change', event: { value: currentValue } });
             }

--- a/src/wwElement_Select.vue
+++ b/src/wwElement_Select.vue
@@ -269,6 +269,7 @@ export default {
         };
 
         const toggleValueAccessibility = value => {
+            console.log('[Select toggleValueAccessibility] Called with value:', value, 'type:', selectType.value);
             const option = Array.from(optionsMap.value).find(([key, option]) => option.value === value);
             if (!option && !options?.length > 1) return;
             if (option?.[1]?.disabled) return;
@@ -281,8 +282,13 @@ export default {
                 if (variableValue.value === value) {
                     // Unselect ?
                     if (props.content.unselectOnClick) {
+                        console.log('[Select toggleValueAccessibility] Single unselect via keyboard');
                         setValue(null);
                         valueChanged = true;
+                        if (props.content.closeOnSelect) {
+                            console.log('[Select toggleValueAccessibility] Closing dropdown due to closeOnSelect');
+                            closeDropdown();
+                        }
                     }
                 } else if (props.content.selectOnClick) {
                     // Select ?
@@ -308,8 +314,13 @@ export default {
                 if (valueIndex >= 0) {
                     // Unelect ?
                     if (props.content.unselectOnClick) {
+                        console.log('[Select toggleValueAccessibility] Multiple unselect via keyboard');
                         currentValue.splice(valueIndex, 1);
                         valueChanged = true;
+                        if (props.content.closeOnSelect) {
+                            console.log('[Select toggleValueAccessibility] Closing dropdown due to closeOnSelect');
+                            closeDropdown();
+                        }
                     }
                 } else if (props.content.selectOnClick) {
                     // Select ?

--- a/src/wwElement_Select.vue
+++ b/src/wwElement_Select.vue
@@ -270,6 +270,7 @@ export default {
             if (!option && !options?.length > 1) return;
             if (option?.[1]?.disabled) return;
 
+            let eventValue;
             if (selectType.value === 'single') {
                 if (variableValue.value === value) {
                     // Unselect ?
@@ -279,6 +280,7 @@ export default {
                     setValue(value);
                     if (props.content.closeOnSelect) closeDropdown();
                 }
+                eventValue = variableValue.value;
             } else {
                 const currentValue = Array.isArray(variableValue.value) ? [...variableValue.value] : [];
                 
@@ -303,9 +305,10 @@ export default {
                 }
 
                 setValue(currentValue);
+                eventValue = currentValue;
             }
 
-            emit('trigger-event', { name: 'change', event: { value: variableValue.value } });
+            emit('trigger-event', { name: 'change', event: { value: eventValue } });
         };
 
         function removeSpecificValue(valueToRemove) {

--- a/src/wwElement_Select.vue
+++ b/src/wwElement_Select.vue
@@ -230,19 +230,12 @@ export default {
         };
 
         const updateValue = value => {
-            console.log('updateValue called with:', {
-                value,
-                selectType: selectType.value,
-                currentVariableValue: variableValue.value
-            });
-            
             if (selectType.value === 'single') {
                 // Check if value is an array
                 if (Array.isArray(value)) {
                     console.warn('Single select component received an array value. Only the first value will be used.');
                     value = value[0];
                 }
-                console.log('Single select: setting value to:', value);
                 setValue(value);
                 emit('trigger-event', { name: 'change', event: { value } });
             } else {
@@ -252,31 +245,19 @@ export default {
                 }
 
                 const currentValue = Array.isArray(variableValue.value) ? [...variableValue.value] : [];
-                console.log('Multiple select processing:', {
-                    incomingValue: value,
-                    currentValue: currentValue
-                });
-                
                 for (let iValue of value) {
                     // Find index using the utility function
                     const valueIndex = findValueIndex(currentValue, iValue);
-                    console.log('Processing value:', iValue, 'found at index:', valueIndex);
 
                     if (valueIndex === -1) {
-                        if (!props.content.limit || currentValue.length < props.content.limit) {
-                            console.log('Adding value:', iValue);
+                        if (!props.content.limit || currentValue.length < props.content.limit)
                             currentValue.push(iValue);
-                        } else {
-                            console.log('Limit reached, not adding:', iValue);
-                        }
                     } else {
-                        console.log('Value already exists at index', valueIndex, '- NOT REMOVING (commented out)');
                         // currentValue.splice(valueIndex, 1);
                         // No need to unselect
                     }
                 }
 
-                console.log('Final value for multiple select:', currentValue);
                 setValue(currentValue);
                 emit('trigger-event', { name: 'change', event: { value: currentValue } });
             }

--- a/src/wwElement_Select.vue
+++ b/src/wwElement_Select.vue
@@ -356,6 +356,13 @@ export default {
 
             console.log('[Select removeSpecificValue] Emitting change event with value:', currentValue);
             emit('trigger-event', { name: 'change', event: { value: currentValue } });
+            
+            // Close dropdown if closeOnSelect is enabled, just like regular selection
+            if (props.content.closeOnSelect) {
+                console.log('[Select removeSpecificValue] Closing dropdown due to closeOnSelect setting');
+                closeDropdown();
+            }
+            
             setTimeout(() => {
                 shouldCloseDropdown.value = true;
             }, 200);


### PR DESCRIPTION
## Summary
• Fix missing change event emission when unselecting an option by clicking on it
• Ensures change event is properly triggered for both single and multi-select modes when unselectOnClick is enabled

## Details
The `unselect()` function in `wwElement_Option.vue` was calling `setValue()` to update the value to null but wasn't emitting the change event like other value change functions. This caused inconsistent behavior where the value would change but listeners wouldn't be notified.

The fix adds the missing `emit('trigger-event', { name: 'change', event: { value } })` call for both single and multi-select scenarios.