### PR TITLE
[WW-3871] Disable bindable for customValidation property

### DIFF
--- a/src/wwElement_Select.vue
+++ b/src/wwElement_Select.vue
@@ -92,21 +92,6 @@ export default {
     emits: ['trigger-event', 'update:content', 'update:sidepanel-content'],
     setup(props, { emit }) {
         /* wwEditor:start */
-        // Migration: Convert bindable validation to non-bindable
-        const componentRawContent = inject('componentRawContent', null);
-        if (componentRawContent?.validation?.__wwtype) {
-            const rawFormula = componentRawContent.validation;
-            emit('update:content:effect', {
-                validation: {
-                    type: rawFormula.__wwtype, // Preserve 'f' or 'js'
-                    code: rawFormula.code,
-                    ...(rawFormula.filter && { filter: rawFormula.filter }),
-                    ...(rawFormula.sort && { sort: rawFormula.sort }),
-                    ...(rawFormula.__wwmap && { __wwmap: rawFormula.__wwmap })
-                }
-            });
-        }
-
         useEditorHint();
         /* wwEditor:end */
         /* wwEditor:start */

--- a/src/wwElement_Select.vue
+++ b/src/wwElement_Select.vue
@@ -92,6 +92,21 @@ export default {
     emits: ['trigger-event', 'update:content', 'update:sidepanel-content'],
     setup(props, { emit }) {
         /* wwEditor:start */
+        // Migration: Convert bindable validation to non-bindable
+        const componentRawContent = inject('componentRawContent', null);
+        if (componentRawContent?.validation?.__wwtype) {
+            const rawFormula = componentRawContent.validation;
+            emit('update:content:effect', {
+                validation: {
+                    type: rawFormula.__wwtype, // Preserve 'f' or 'js'
+                    code: rawFormula.code,
+                    ...(rawFormula.filter && { filter: rawFormula.filter }),
+                    ...(rawFormula.sort && { sort: rawFormula.sort }),
+                    ...(rawFormula.__wwmap && { __wwmap: rawFormula.__wwmap })
+                }
+            });
+        }
+
         useEditorHint();
         /* wwEditor:end */
         /* wwEditor:start */

--- a/ww-config.js
+++ b/ww-config.js
@@ -979,7 +979,7 @@ export default {
             type: 'Formula',
             defaultValue: '',
             states: true,
-            bindable: true,
+            bindable: false,
             responsive: true,
             hidden: (content, sidePanelContent) => !sidePanelContent.form?.uid || !content.customValidation,
         },


### PR DESCRIPTION
## Summary
- Disable bindable property for customValidation in form input configuration

## Test plan
- [ ] Verify customValidation property is no longer bindable in the editor
- [ ] Confirm form validation still works correctly