### PR TITLE
WW-4643 Open the dropdown on mount when initial state is open

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/kevinbarfleur/Github/ww-input-select/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/kevinbarfleur/Github/ww-input-select/node_modules

--- a/src/wwElement_Select.vue
+++ b/src/wwElement_Select.vue
@@ -994,6 +994,7 @@ export default {
                 debounce(syncFloating, 300);
                 observeTriggerSize();
             });
+            if (initialState.value === 'open') openDropdown();
             wwLib.getFrontDocument().addEventListener('click', handleClickOutside);
             wwLib.getFrontWindow().addEventListener('scroll', syncFloating);
             wwLib.getFrontWindow().addEventListener('resize', syncFloating);

--- a/src/wwElement_Select.vue
+++ b/src/wwElement_Select.vue
@@ -831,7 +831,7 @@ export default {
         watch(
             initialState,
             () => {
-                if (initialState.value && initialState.value === 'open') openDropdown();
+                if (!isEditing.value && initialState.value && initialState.value === 'open') openDropdown();
                 else if (!forceOpenInEditor.value) closeDropdown();
             },
             { immediate: true }
@@ -843,7 +843,7 @@ export default {
             nextTick(debounce(syncFloating, 300));
 
             if (forceOpenInEditor.value && isEditing.value) openDropdown();
-            else if (initialState.value && initialState.value === 'open') openDropdown();
+            else if (!isEditing.value && initialState.value && initialState.value === 'open') openDropdown();
             else closeDropdown();
         });
 
@@ -994,7 +994,7 @@ export default {
                 debounce(syncFloating, 300);
                 observeTriggerSize();
             });
-            if (initialState.value === 'open') openDropdown();
+            if (!isEditing.value && initialState.value === 'open') openDropdown();
             wwLib.getFrontDocument().addEventListener('click', handleClickOutside);
             wwLib.getFrontWindow().addEventListener('scroll', syncFloating);
             wwLib.getFrontWindow().addEventListener('resize', syncFloating);


### PR DESCRIPTION
The immediate watcher applied the initial state during setup, before the trigger ref exists, so openDropdown silently no-oped and the published runtime never re-fired it. One line in onMounted re-applies it once mounted.